### PR TITLE
let delete phrase collect oci hook logs

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -15,6 +15,7 @@ type Config struct {
 
 	// from command line args
 	OCISpecFilename string
+	OCILogFilename  string
 	ID              string
 }
 

--- a/delete.go
+++ b/delete.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+	"github.com/projecteru2/docker-cni/config"
+	log "github.com/sirupsen/logrus"
+)
+
+func postHandleDelete(conf config.Config) (err error) {
+	if conf.OCILogFilename == "" {
+		return errors.Errorf("empty oci log filename")
+	}
+
+	logContent, err := ioutil.ReadFile(conf.OCILogFilename)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	log.Warnf("oci log: %s", string(logContent))
+	return
+}


### PR DESCRIPTION
Provided the oci poststop hooks fail, we must catch the error log under the bundle path.

Background info: poststop hooks won't affect container life cycle, and `runc delete` returns 0 even though the poststop hooks fail, according to the spec.